### PR TITLE
IE8下使用es3ify-loader解决babel的编译兼容性问题时，module.default未编译导致抛出错误SCRIPT1010

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ module.exports.pitch = function (remainingRequest) {
     '        if(!component) {',
     '            require.ensure([], function() {',
     '                var module = require(' + JSON.stringify(moduleRequest) + ');',
-    '                component = module.__esModule ? module.default : module;',
+    '                component = module.__esModule ? module["default"] : module;',
     '                if(callback) callback(component);',
     '            }' + chunkNameParam + ');',
     '        } else if(callback) callback(component);',


### PR DESCRIPTION
`ES6`使用`babel`编译时，对于`IE8`的编译有`BUG`；
换用`es3ify-loader`对`ES6`进行编译，但`es3ify-loader`并未编译`react-router-loader`中的`module.default`，导致`IE8`跑出错误`SCRIPT1010: 缺少标识符`。

将`module.default`修改为`module["default"]`可以修复该bug
